### PR TITLE
Promote deployment | busybox/registry.hub.docker.com/library/busybox:v0.39

### DIFF
--- a/deployments/busybox/deployment_id/dev/kustomization.yaml
+++ b/deployments/busybox/deployment_id/dev/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 images:
   - name: busybox-api-image
     newName: registry.hub.docker.com/library/busybox
-    newTag: v0.38
+    newTag: v0.39
   - name: busybox-db-image
     newName: registry.hub.docker.com/library/postgres
     newTag: 10.11


### PR DESCRIPTION
```
image_version="registry.hub.docker.com/library/busybox:v0.39"
image_placeholder="busibox-api"
deployment="busybox"
```