### PR TITLE
Promote deployment | busybox/busybox-api:0.43

### DIFF
--- a/deployments/busybox/deployment_id/dev/kustomization.yaml
+++ b/deployments/busybox/deployment_id/dev/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 images:
   - name: busybox-api-image
     newName: registry.hub.docker.com/library/busybox
-    newTag: v0.46
+    newTag: "0.43"
   - name: busybox-db-image
     newName: registry.hub.docker.com/library/postgres
     newTag: 10.11


### PR DESCRIPTION
```
image_version="registry.hub.docker.com/library/busybox:0.43"
image_placeholder="busybox-api"
deployment="busybox"
```