### PR TITLE
[cicd | dev] promote deployment

### DIFF
--- a/deployments/busybox/deployment_id/dev/kustomization.yaml.tmp
+++ b/deployments/busybox/deployment_id/dev/kustomization.yaml.tmp
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+images:
+  - name: busybox-api-image
+    newName: registry.hub.docker.com/library/busybox
+    newTag: "0.66-dev"
+  - name: busybox-db-image
+    newName: registry.hub.docker.com/library/postgres
+    newTag: 10.11
+  - name: busybox-cache-image
+    newName: registry.hub.docker.com/library/redis
+    newTag: '4.5'

--- a/payload.json
+++ b/payload.json
@@ -7,7 +7,7 @@
   },
   {
     "image_id": "registry.io/cd-gitops-demo-image-b",
-    "image_tag": "v1.0.5-dev",
+    "image_tag": "v1.0.4",
     "image_placeholder": "cd-demo-b-image-placeholder",
     "deployment": "busybox"
   }

--- a/pr-body.md
+++ b/pr-body.md
@@ -5,8 +5,8 @@ Release PR in `dev` environment
 Deployment to `dev1` will take place when this PR is merged 
 
 Comment to promote these changes to `staging` environment:
-- `bump/`
-- `promote/`
+- `/bump`
+- `/promote`
 
 Payload:
 
@@ -20,7 +20,7 @@ Payload:
   },
   {
     "image_id": "registry.io/cd-gitops-demo-image-b",
-    "image_tag": "v1.0.5-dev",
+    "image_tag": "v1.0.4",
     "image_placeholder": "cd-demo-b-image-placeholder",
     "deployment": "busybox"
   }


### PR DESCRIPTION
Release PR in `dev` environment

`/<deployment>/deployment_id/dev/`

Deployment to `dev1` will take place when this PR is merged 

Comment to promote these changes to `staging` environment:
- `/bump`
- `/promote`

Payload:

```json
[
  {
    "image_id": "registry.io/cd-gitops-demo-image-a",
    "image_tag": "cf9854",
    "image_placeholder": "",
    "deployment": "busybox"
  },
  {
    "image_id": "registry.io/cd-gitops-demo-image-b",
    "image_tag": "v1.0.4",
    "image_placeholder": "cd-demo-b-image-placeholder",
    "deployment": "busybox"
  }
]
```
